### PR TITLE
Support for Oracle Enterprise Linux

### DIFF
--- a/dcos_installer/action_lib.py
+++ b/dcos_installer/action_lib.py
@@ -360,8 +360,15 @@ if ([ x$dist == 'xcoreos' ]); then
   exit 0
 fi
 
-if ([ x$dist != 'xrhel' ] && [ x$dist != 'xcentos' ]); then
-  echo "$dist is not supported. Only RHEL and CentOS are supported" >&2
+if ([ x$dist != 'xrhel' ] && [ x$dist != 'xcentos' ] && [ x$dist != 'xol' ]); then
+  echo "$dist is not supported. Only RHEL, CentOS and Oracle Enterprise Linux are supported" >&2
+  exit 0
+fi
+
+kernel_version=`uname -r`
+
+if ([ x$dist != 'xol' ] && [ kernel_version == *"uek"* ]); then
+  echo "Unbreakable Enterprise Kernel is not supported on Oracle Enterprise Linux. Switch to the other Kernel" >&2
   exit 0
 fi
 


### PR DESCRIPTION
DCOS can be installed on Oracle Enterprise Linux 7.2 and 7.3(Fork of RHEL 7.2/7.3) if booted from kernel-3.10.0-514.el7 which ships along with the default kernel kernel-uek-4.1.12-61.1.18.el7uek

## High Level Description

It allows compatibility with OEL(Oracle Enterprose Linux)

## Related Issues

 N/A

## Checklist for all PR's

N/A

## Checklist for component/package updates:

N/A
___
**PLEASE FILL IN THE TEMPLATE ABOVE** / **DO NOT REMOVE ANY SECTIONS ABOVE THIS LINE**

## Instructions and Review Process

**What is the review process and when will my changes land?**

All PRs require 2 approvals using github's [pull request reviews](https://help.github.com/articles/about-pull-request-reviews/).

Reviewers should be:
* Developers who understand the code being modified.
* Developers responsible for code that interacts with or depends on the code being modified.

It is best to proactively ask for 2 reviews by @mentioning the candidate reviewers in the PR comments area. The responsibility is on the developer submitting the PR to follow-up with reviewers and make sure a PR is reviewed in a timely manner. Once a PR has **2 ship-it's**, **no red reviews**, and **all tests are green** it will be included in the [next train](https://github.com/dcos/dcos/blob/master/contributing.md).
